### PR TITLE
Fix 'refernece' typo in page factories

### DIFF
--- a/input/pagecontent/page-factories.md
+++ b/input/pagecontent/page-factories.md
@@ -2,7 +2,7 @@ The IG publisher can be configured to produce a page for each item in a list.
 There can be multiple page factories. Each page factory is registered as a 
 parameter using the ```page-factory``` parameter.
 
-Each page factory is a refernece to a page factory control file which is a json file 
+Each page factory is a reference to a page factory control file which is a json file 
 with the following format:
 
 ```json


### PR DESCRIPTION
I have to admit I don't quite grok what page factories are useful for. Is there a few examples of them in the wild?