### PR TITLE
Add ig-parameters code: dynamic-source-viewers

### DIFF
--- a/input/resources/codesystem-ig-parameters.xml
+++ b/input/resources/codesystem-ig-parameters.xml
@@ -2310,4 +2310,22 @@
     </property>
   </concept>
 
+  <concept>
+    <code value="dynamic-source-viewers"/>
+    <display value="dynamic-source-viewers"/>
+    <definition value="When 'true', the json/xml/ttl &quot;view source&quot; pages are rendered client-side from the raw resource file (fetched and syntax-highlighted in the browser) instead of baking the highlighted source into each page, greatly reducing page size. The in-source FHIR reference hyperlinks added by the server-side renderer are not present in this view. Requires the raw json/xml/ttl formats to also be generated."/>
+    <property>
+      <code value="repeats"/>
+      <valueBoolean value="false"/>
+    </property>
+    <property>
+      <code value="string-format"/>
+      <valueString value="true|false"/>
+    </property>
+    <property>
+      <code value="missing"/>
+      <valueString value="false"/>
+    </property>
+  </concept>
+
 </CodeSystem>


### PR DESCRIPTION
## Summary

Registers a new IG Publisher parameter code `dynamic-source-viewers` in the `ig-parameters` `CodeSystem` (`http://hl7.org/fhir/tools/CodeSystem/ig-parameters`).

A companion change to the IG Publisher (HL7/fhir-ig-publisher) adds an opt-in IG parameter `dynamic-source-viewers`. When set to `true`, the json/xml/ttl "view source" pages (`*.json.html` / `*.xml.html` / `*.ttl.html`) are rendered client-side from the raw resource file (fetched + syntax-highlighted in the browser) instead of baking the highlighted source into every page — cutting those pages from ~70–90 KB to ~12 KB.

Because the code was not in the tooling `ig-parameters` value set, any IG that opts in currently gets a validation error:

```
ERROR: ImplementationGuide... The value provided ('dynamic-source-viewers') was not found in
the value set 'ig-parameters Codes ValueSet'
(http://hl7.org/fhir/tools/ValueSet/ig-parameters|1.1.2)
```

The `ig-parameters` ValueSet includes the whole CodeSystem (`compose.include.system = http://hl7.org/fhir/tools/CodeSystem/ig-parameters`), so adding the concept here resolves the validation error. This is the standard registration step done for every publisher parameter (e.g. `produce-jekyll-data`, `shownav`, `path-resource`).

## What changed

Added one concept to `input/resources/codesystem-ig-parameters.xml`:

| field | value |
| --- | --- |
| code | `dynamic-source-viewers` |
| display | `dynamic-source-viewers` |
| `repeats` | `false` |
| `string-format` | `true|false` |
| `missing` | `false` (default: off) |

Modelled on the existing boolean toggle `shownav`, but defaulting to `false`.

## Notes

- Pure additive change — one new CodeSystem concept, no other concepts modified. No breaking change.
- Code string matches the publisher exactly: `dynamic-source-viewers` (lowercase, hyphenated).
- Companion publisher PR: https://github.com/HL7/fhir-ig-publisher/pull/1329

